### PR TITLE
fix not found ActiveRecordSchemaProvider

### DIFF
--- a/config/di-web.php
+++ b/config/di-web.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Cycle\Database\DatabaseProviderInterface;
 use Psr\Container\ContainerInterface;
 use Yiisoft\Db\Connection\ConnectionInterface;
-use Yiisoft\Yii\Debug\Api\Inspector\ActiveRecord\ActiveRecordSchemaProvider;
+use Yiisoft\Yii\Debug\Api\Inspector\Database\ActiveRecord\ActiveRecordSchemaProvider;
 use Yiisoft\Yii\Debug\Api\Inspector\Database\Cycle\CycleSchemaProvider;
 use Yiisoft\Yii\Debug\Api\Inspector\Database\SchemaProviderInterface;
 use Yiisoft\Yii\Debug\Api\Repository\CollectorRepository;

--- a/src/Inspector/Database/ActiveRecord/ActiveRecordSchemaProvider.php
+++ b/src/Inspector/Database/ActiveRecord/ActiveRecordSchemaProvider.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Yiisoft\Yii\Debug\Api\Inspector\ActiveRecord;
+namespace Yiisoft\Yii\Debug\Api\Inspector\Database\ActiveRecord;
 
 use Yiisoft\ActiveRecord\ActiveRecord;
 use Yiisoft\ActiveRecord\ActiveRecordFactory;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 


```
Yiisoft\Di\NotFoundException
No definition or class found or resolvable for "Yiisoft\Yii\Debug\Api\Inspector\ActiveRecord\ActiveRecordSchemaProvider" while building "Yiisoft\Yii\Debug\Api\Inspector\ActiveRecord\ActiveRecordSchemaProvider".

1. in vendor\yiisoft\di\src\Container.php at line 533
```

```php
private function buildInternal(string $id)
{
    if ($this->definitions->has($id)) {
        $definition = DefinitionNormalizer::normalize($this->definitions->get($id), $id);

        return $definition->resolve($this->get(ContainerInterface::class));
    }

    throw new NotFoundException($id, $this->definitions->getBuildStack());
}
```